### PR TITLE
Offboard timesync

### DIFF
--- a/mavros/include/mavros/utils.hpp
+++ b/mavros/include/mavros/utils.hpp
@@ -53,6 +53,7 @@ enum class timesync_mode
   MAVLINK,              //!< Via TIMESYNC message
   ONBOARD,
   PASSTHROUGH,
+  OFFBOARD,
 };
 
 /**

--- a/mavros/src/lib/enum_to_string.cpp
+++ b/mavros/src/lib/enum_to_string.cpp
@@ -325,11 +325,12 @@ std::string to_string(MAV_STATE e)
 // ]]]
 
 //! timesync_mode values
-static const std::array<const std::string, 4> timesync_mode_strings{{
+static const std::array<const std::string, 5> timesync_mode_strings{{
 /*  0 */ "NONE",
 /*  1 */ "MAVLINK",
 /*  2 */ "ONBOARD",
 /*  3 */ "PASSTHROUGH",
+    /*  4 */ "OFFBOARD",
 }};
 
 

--- a/mavros/src/lib/enum_to_string.cpp
+++ b/mavros/src/lib/enum_to_string.cpp
@@ -330,7 +330,7 @@ static const std::array<const std::string, 5> timesync_mode_strings{{
 /*  1 */ "MAVLINK",
 /*  2 */ "ONBOARD",
 /*  3 */ "PASSTHROUGH",
-    /*  4 */ "OFFBOARD",
+/*  4 */ "OFFBOARD",
 }};
 
 

--- a/mavros/src/plugins/sys_time.cpp
+++ b/mavros/src/plugins/sys_time.cpp
@@ -354,13 +354,13 @@ private:
       time_unix.source = time_ref_source;
 
       time_ref_pub->publish(time_unix);
-    } else {
-      auto ts_mode = uas->get_timesync_mode();
-      if (ts_mode == TSM::OFFBOARD) {
-        const auto time_unix_ns = static_cast<int64_t>(mtime.time_unix_usec * 1000);
-        const auto time_boot_ns = static_cast<int64_t>(mtime.time_boot_ms * 1000000);
-        add_timesync_observation(time_unix_ns - time_boot_ns, time_unix_ns, time_boot_ns);
-      }
+    }
+
+    auto ts_mode = uas->get_timesync_mode();
+    if (ts_mode == TSM::OFFBOARD) {
+      const auto time_unix_ns = static_cast<int64_t>(mtime.time_unix_usec * 1000);
+      const auto time_boot_ns = static_cast<int64_t>(mtime.time_boot_ms * 1000000);
+      add_timesync_observation(time_unix_ns - time_boot_ns, time_unix_ns, time_boot_ns);
     }
   }
 

--- a/mavros/src/plugins/sys_time.cpp
+++ b/mavros/src/plugins/sys_time.cpp
@@ -357,11 +357,9 @@ private:
     } else {
       auto ts_mode = uas->get_timesync_mode();
       if (ts_mode == TSM::OFFBOARD) {
-        const uint64_t time_unix_ns = mtime.time_unix_usec * 1000;
-        const uint64_t time_boot_ns = mtime.time_boot_ms * 100000;
-        add_timesync_observation(
-            static_cast<int64_t>(time_unix_ns - time_boot_ns), time_unix_ns,
-            time_boot_ns);
+        const auto time_unix_ns = static_cast<int64_t>(mtime.time_unix_usec * 1000);
+        const auto time_boot_ns = static_cast<int64_t>(mtime.time_boot_ms * 1000000);
+        add_timesync_observation(time_unix_ns - time_boot_ns, time_unix_ns, time_boot_ns);
       }
     }
   }

--- a/mavros/src/plugins/sys_time.cpp
+++ b/mavros/src/plugins/sys_time.cpp
@@ -354,13 +354,15 @@ private:
       time_unix.source = time_ref_source;
 
       time_ref_pub->publish(time_unix);
-    }
 
-    auto ts_mode = uas->get_timesync_mode();
-    if (ts_mode == TSM::OFFBOARD) {
-      const auto time_unix_ns = static_cast<int64_t>(mtime.time_unix_usec * 1000);
-      const auto time_boot_ns = static_cast<int64_t>(mtime.time_boot_ms * 1000000);
-      add_timesync_observation(time_unix_ns - time_boot_ns, time_unix_ns, time_boot_ns);
+      auto ts_mode = uas->get_timesync_mode();
+      if (ts_mode == TSM::OFFBOARD) {
+        const auto time_unix_ns = static_cast<int64_t>(mtime.time_unix_usec * 1000);
+        const auto time_boot_ns = static_cast<int64_t>(mtime.time_boot_ms * 1000000);
+        add_timesync_observation(time_unix_ns - time_boot_ns, time_unix_ns, time_boot_ns);
+      }
+    } else{
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 60000, "TM: Wrong FCU time.");
     }
   }
 


### PR DESCRIPTION
Add offboard timesync mode that uses the onboard RTC time instead of ROS time.